### PR TITLE
Enhance layout scenarios for flex, grid, and iBlock

### DIFF
--- a/shots/genre/box.md
+++ b/shots/genre/box.md
@@ -12,7 +12,7 @@ A horizontal scrolling container with snapping and custom inline sizing constrai
 ```html
 …<div class="
   $Box(100px<100%<800px,scroll,snapInlineMandatory,scrollPadding(0,1rem))
-  |*$BoxItem(snapCenter,scrollMargin(0,1rem))">
+  |$BoxItem(snapCenter,scrollMargin(0,1rem))">
   <div>…</div>
   <div>…</div>
 </div>…
@@ -55,7 +55,7 @@ A fixed-size vertical scrolling block container with hidden overflow on the inli
 ```html
 …<div class="
   $Box(100%,300px,hiddenScroll,snapBlockMandatory)
-  |*$BoxItem(snapStart,snapAlways)">
+  |$BoxItem(snapStart,snapAlways)">
   …
   <div>…</div>
   …
@@ -234,7 +234,7 @@ A carousel layout where the items stop normally and align at the start and end u
 ```html
 …<div class="
   $Flex(row)$Box(auto,snap)
-  |*$BoxItem(snapStartEnd,snapNormal)">
+  |$BoxItem(snapStartEnd,snapNormal)">
   <div class="slide">…</div>
   <div class="slide">…</div>
 </div>…
@@ -281,7 +281,7 @@ A vertical content feed where the Box container masks overflow outside of the bl
 ```html
 …<div class="
   $Box(hiddenScroll,scrollPadding(2rem,0))
-  |*$BoxItem(scrollMargin(1rem,0))">
+  |$BoxItem(scrollMargin(1rem,0))">
   <article>…</article>
   <article>…</article>
 </div>…

--- a/shots/genre/flex.md
+++ b/shots/genre/flex.md
@@ -1,11 +1,11 @@
 **description:**
 A vertical Flex settings panel with shared item basis.
-**userInstruction:** The settings panel needs to be a column layout with gaps, and all child settings items should share a 100px flex basis. Use the general child selector |$ for the flex items.
+**userInstruction:** The settings panel needs to be a column layout with gaps, and all child settings items should share a 100px flex basis.
 **before:**
 ```html
-…<div class="$Flex">
-  <div class="setting">…</div>
-  <div class="setting">…</div>
+…<div class="settings $Flex">
+  <div>…</div>
+  <div>…</div>
 </div>…
 ```
 **after:**
@@ -13,8 +13,8 @@ A vertical Flex settings panel with shared item basis.
 …<div class="
   $Flex(column,gap(0.5rem),padding(1rem))
   |$FlexItem(100px)">
-  <div class="setting">…</div>
-  <div class="setting">…</div>
+  <div>…</div>
+  <div>…</div>
 </div>…
 ```
 **css:**
@@ -80,7 +80,7 @@ A reversed Flex action bar with mixed growth.
 
 **description:**
 A wrapping Flex card grid with fixed tile sizing.
-**userInstruction:** The flex cards aren't wrapping to the next line when the screen is too small, and they need fixed width/height (150px/120px). Add wrap and use |$ to style the items.
+**userInstruction:** The flex cards aren't wrapping to the next line when the screen is too small, and they need fixed width/height (150px/120px).
 **before:**
 ```html
 …<div class="$Flex(gap(1rem,2rem))">
@@ -132,7 +132,7 @@ A wrapping Flex card grid with fixed tile sizing.
 
 **description:**
 A wrapping Flex toolbar where key actions are reordered and aligned differently once the row starts to fill up.
-**userInstruction:** The visual order of the toolbar items needs to be rearranged. Set a default order of 3 for all items using |$, but move .two to the front (order 1) and .three to the middle (order 2), adjusting their individual alignments as well.
+**userInstruction:** The visual order of the toolbar items needs to be rearranged. Set a default order of 3 for all items, but move .two to the front (order 1) and .three to the middle (order 2), adjusting their individual alignments as well.
 **before:**
 ```html
 …<div class="$Flex(start,gap(1rem),padding(1rem),wrap)">
@@ -185,7 +185,7 @@ A wrapping Flex toolbar where key actions are reordered and aligned differently 
 
 **description:**
 A centered Flex row with a stretched featured item.
-**userInstruction:** The items are centered, but the .featured item should stretch vertically to fill the height of the row.
+**userInstruction:** The items are centered, but the featured item should stretch vertically to fill the height of the row.
 **before:**
 ```html
 …<div class="$Flex(center,gap(1rem),padding(1rem),wrap)">
@@ -273,7 +273,7 @@ A scrollable Flex control strip with mixed item sizing.
 
 **description:**
 A Flex comparison row with a flexible lead item, supporting items aligned independently, and a note moved later in the visual order.
-**userInstruction:** The row needs more complex alignment. The first item should grow with a 200px basis, the middle items should align to center and end, and the .note should be pushed to the very end of the flex order.
+**userInstruction:** The row needs more complex alignment. The first item should grow with a 200px basis, the middle items should align to center and end, and the note item should be pushed to the very end of the flex order.
 **before:**
 ```html
 …<div class="$Flex(row,gap(1rem),padding(1rem),wrap)">
@@ -329,7 +329,7 @@ A Flex comparison row with a flexible lead item, supporting items aligned indepe
 
 **description:**
 A Flex inheritance example with parent item defaults and targeted child overrides.
-**userInstruction:** Apply a default flex grow of 1 and basis of 180px to all items using |$. Then, make the .wide element grow twice as fast with a 280px basis, and pin the .pin element to the end.
+**userInstruction:** Apply a default flex grow of 1 and basis of 180px to all items. Then, make the .wide element grow twice as fast with a 280px basis, and pin the pinned element to the end.
 **before:**
 ```html
 …<div class="$Flex(gap(1rem),padding(1rem),wrap)">

--- a/shots/genre/flex.md
+++ b/shots/genre/flex.md
@@ -1,8 +1,22 @@
 **description:**
 A vertical Flex settings panel with shared item basis.
-**csss:**
- $Flex(column,gap(0.5rem),padding(1rem))
-|$FlexItem(100px)
+**userInstruction:** The settings panel needs to be a column layout with gaps, and all child settings items should share a 100px flex basis. Use the general child selector |$ for the flex items.
+**before:**
+```html
+…<div class="$Flex">
+  <div class="setting">…</div>
+  <div class="setting">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(column,gap(0.5rem),padding(1rem))
+  |$FlexItem(100px)">
+  <div class="setting">…</div>
+  <div class="setting">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(column\,gap\(0\.5rem\)\,padding\(1rem\)\) {
@@ -25,10 +39,24 @@ A vertical Flex settings panel with shared item basis.
 
 **description:**
 A reversed Flex action bar with mixed growth.
-**csss:**
- $Flex(rowReverse,gap(0.5rem),padding(1rem))
-|:nth-child(1)$flexItem(1)
-|:nth-child(2)$flexItem(2)
+**userInstruction:** The action bar is currently left-to-right. Reverse the row direction and make the second button grow twice as fast as the first button.
+**before:**
+```html
+…<div class="$Flex(row,gap(0.5rem),padding(1rem))">
+  <button>…</button>
+  <button>…</button>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(rowReverse,gap(0.5rem),padding(1rem))
+  |:nth-child(1)$flexItem(1)
+  |:nth-child(2)$flexItem(2)">
+  <button>…</button>
+  <button>…</button>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(rowReverse\,gap\(0\.5rem\)\,padding\(1rem\)\) {
@@ -52,9 +80,23 @@ A reversed Flex action bar with mixed growth.
 
 **description:**
 A wrapping Flex card grid with fixed tile sizing.
-**csss:**
- $Flex(wrap,gap(1rem,2rem))
-|$FlexItem(margin(5px,1rem))$Box(150px,120px)$BoxItem(scrollMargin(10px))
+**userInstruction:** The flex cards aren't wrapping to the next line when the screen is too small, and they need fixed width/height (150px/120px). Add wrap and use |$ to style the items.
+**before:**
+```html
+…<div class="$Flex(gap(1rem,2rem))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(wrap,gap(1rem,2rem))
+  |$FlexItem(margin(5px,1rem))$Box(150px,120px)$BoxItem(scrollMargin(10px))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(wrap\,gap\(1rem\,2rem\)\) {
@@ -90,11 +132,27 @@ A wrapping Flex card grid with fixed tile sizing.
 
 **description:**
 A wrapping Flex toolbar where key actions are reordered and aligned differently once the row starts to fill up.
-**csss:**
- $Flex(start,gap(1rem),padding(1rem),wrap)
-|$FlexItem(order(3),start,margin(1rem))
-|.two$flexItem(order(1),center)
-|.three$flexItem(order(2),end)
+**userInstruction:** The visual order of the toolbar items needs to be rearranged. Set a default order of 3 for all items using |$, but move .two to the front (order 1) and .three to the middle (order 2), adjusting their individual alignments as well.
+**before:**
+```html
+…<div class="$Flex(start,gap(1rem),padding(1rem),wrap)">
+  <button class="one">…</button>
+  <button class="two">…</button>
+  <button class="three">…</button>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(start,gap(1rem),padding(1rem),wrap)
+  |$FlexItem(order(3),start,margin(1rem))
+  |.two$flexItem(order(1),center)
+  |.three$flexItem(order(2),end)">
+  <button class="one">…</button>
+  <button class="two">…</button>
+  <button class="three">…</button>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(start\,gap\(1rem\)\,padding\(1rem\)\,wrap\) {
@@ -127,9 +185,23 @@ A wrapping Flex toolbar where key actions are reordered and aligned differently 
 
 **description:**
 A centered Flex row with a stretched featured item.
-**csss:**
- $Flex(center,gap(1rem),padding(1rem),wrap)
-|.featured$FlexItem(stretch)
+**userInstruction:** The items are centered, but the .featured item should stretch vertically to fill the height of the row.
+**before:**
+```html
+…<div class="$Flex(center,gap(1rem),padding(1rem),wrap)">
+  <div>…</div>
+  <div class="featured">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(center,gap(1rem),padding(1rem),wrap)
+  |.featured$FlexItem(stretch)">
+  <div>…</div>
+  <div class="featured">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(center\,gap\(1rem\)\,padding\(1rem\)\,wrap\) {
@@ -152,11 +224,27 @@ A centered Flex row with a stretched featured item.
 
 **description:**
 A scrollable Flex control strip with mixed item sizing.
-**csss:**
- $Flex(gap(1rem),padding(1rem))$box(scroll)
-|:nth-child(1)$flexItem(1)
-|:nth-child(2)$flexItem(center)
-|:nth-child(3)$flexItem(1,0.5)
+**userInstruction:** The control strip is overflowing its container. Add a scroll box to it, and adjust the flex-grow and flex-shrink properties of the children so they respond correctly when space is tight.
+**before:**
+```html
+…<div class="$Flex(gap(1rem),padding(1rem))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(gap(1rem),padding(1rem))$box(scroll)
+  |:nth-child(1)$flexItem(1)
+  |:nth-child(2)$flexItem(center)
+  |:nth-child(3)$flexItem(1,0.5)">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(gap\(1rem\)\,padding\(1rem\)\)\$box\(scroll\) {
@@ -185,12 +273,30 @@ A scrollable Flex control strip with mixed item sizing.
 
 **description:**
 A Flex comparison row with a flexible lead item, supporting items aligned independently, and a note moved later in the visual order.
-**csss:**
- $Flex(row,gap(1rem),padding(1rem),wrap)
-|:nth-child(1)$flexItem(1,200px)
-|:nth-child(2)$flexItem(center)
-|:nth-child(3)$flexItem(end)
-|.note$flexItem(order(4),margin(1rem))
+**userInstruction:** The row needs more complex alignment. The first item should grow with a 200px basis, the middle items should align to center and end, and the .note should be pushed to the very end of the flex order.
+**before:**
+```html
+…<div class="$Flex(row,gap(1rem),padding(1rem),wrap)">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+  <div class="note">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(row,gap(1rem),padding(1rem),wrap)
+  |:nth-child(1)$flexItem(1,200px)
+  |:nth-child(2)$flexItem(center)
+  |:nth-child(3)$flexItem(end)
+  |.note$flexItem(order(4),margin(1rem))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+  <div class="note">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(row\,gap\(1rem\)\,padding\(1rem\)\,wrap\) {
@@ -223,11 +329,27 @@ A Flex comparison row with a flexible lead item, supporting items aligned indepe
 
 **description:**
 A Flex inheritance example with parent item defaults and targeted child overrides.
-**csss:**
- $Flex(gap(1rem),padding(1rem),wrap)
-|$FlexItem(1,180px,margin(0.5rem))
-|.wide$flexItem(2,280px)
-|.pin$flexItem(order(5),end)
+**userInstruction:** Apply a default flex grow of 1 and basis of 180px to all items using |$. Then, make the .wide element grow twice as fast with a 280px basis, and pin the .pin element to the end.
+**before:**
+```html
+…<div class="$Flex(gap(1rem),padding(1rem),wrap)">
+  <div>…</div>
+  <div class="wide">…</div>
+  <div class="pin">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Flex(gap(1rem),padding(1rem),wrap)
+  |$FlexItem(1,180px,margin(0.5rem))
+  |.wide$flexItem(2,280px)
+  |.pin$flexItem(order(5),end)">
+  <div>…</div>
+  <div class="wide">…</div>
+  <div class="pin">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Flex\(gap\(1rem\)\,padding\(1rem\)\,wrap\) {
@@ -258,16 +380,44 @@ A Flex inheritance example with parent item defaults and targeted child override
 ```
 
 **description:** Applies uniform 1rem margin on all flex children.
-**csss:** |*$flexItem(margin(1rem))
+**userInstruction:** Change the wildcard |*$ to just the generic child selector |$ to apply margins to flex items.
+**before:**
+```html
+…<div class="|*$flexItem(margin(1rem))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="|$flexItem(margin(1rem))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
-.\|\*\$flexItem\(margin\(1rem\)\)>* {
+.\|\$flexItem\(margin\(1rem\)\)>* {
   margin: 1rem;
 }
 ```
 
 **description:** Applies 2rem bottom margin on .a flex child.
-**csss:** |.a$flexItem(margin(0,0,2rem))
+**userInstruction:** Add a 2rem bottom margin specifically to the child with class .a.
+**before:**
+```html
+…<div class="|$flexItem(margin(1rem))">
+  <div class="a">…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="|$flexItem(margin(1rem)) |.a$flexItem(margin(0,0,2rem))">
+  <div class="a">…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\|\.a\$flexItem\(margin\(0\,0\,2rem\)\)>:where(.a) {

--- a/shots/genre/grid.md
+++ b/shots/genre/grid.md
@@ -1,8 +1,24 @@
 **description:**
 A two-column Grid shell with a spanning lead item.
-**csss:**
- $Grid(cols(1fr,2fr),rows(auto),gap(1rem),padding(1rem))
-|:nth-child(1)$gridItem(column(1,span(2)))
+**userInstruction:** The grid currently has equally sized columns, but the second column should be twice as wide as the first. Also, make the first child span across both columns to act as a header.
+**before:**
+```html
+…<div class="$Grid(cols(1fr,1fr),gap(1rem),padding(1rem))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(cols(1fr,2fr),rows(auto),gap(1rem),padding(1rem))
+  |:nth-child(1)$gridItem(column(1,span(2)))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(cols\(1fr\,2fr\)\,rows\(auto\)\,gap\(1rem\)\,padding\(1rem\)\) {
@@ -24,9 +40,25 @@ A two-column Grid shell with a spanning lead item.
 
 **description:**
 A column-flow Grid board with a tall spanning item.
-**csss:**
- $Grid(rows(repeat(3,1fr)),column,gap(0.5rem),padding(1rem))
-|:nth-child(2)$gridItem(row(1,span(2)))
+**userInstruction:** The grid flows in rows by default. Change it to flow in columns with 3 equal rows, and make the second item span across the first two rows.
+**before:**
+```html
+…<div class="$Grid(gap(0.5rem),padding(1rem))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(rows(repeat(3,1fr)),column,gap(0.5rem),padding(1rem))
+  |:nth-child(2)$gridItem(row(1,span(2)))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(rows\(repeat\(3\,1fr\)\)\,column\,gap\(0\.5rem\)\,padding\(1rem\)\) {
@@ -48,11 +80,27 @@ A column-flow Grid board with a tall spanning item.
 
 **description:**
 A feature Grid with a spanning hero and a side card that can be aligned independently for contrast.
-**csss:**
- $Grid(center,cols(repeat(2,1fr)),gap(1rem),padding(1rem))
-|$gridItem(stretch)
-|.hero$GridItem(column(1,span(2)),margin(1rem))
-|.aside$GridItem(startEnd,row(2))
+**userInstruction:** Set the grid to stretch all items by default using |$. Then, make the .hero item span two columns with a 1rem margin, and align the .aside to the start and end of row 2.
+**before:**
+```html
+…<div class="$Grid(center,cols(repeat(2,1fr)),gap(1rem),padding(1rem))">
+  <div class="hero">…</div>
+  <div class="aside">…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(center,cols(repeat(2,1fr)),gap(1rem),padding(1rem))
+  |$gridItem(stretch)
+  |.hero$GridItem(column(1,span(2)),margin(1rem))
+  |.aside$GridItem(startEnd,row(2))">
+  <div class="hero">…</div>
+  <div class="aside">…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(center\,cols\(repeat\(2\,1fr\)\)\,gap\(1rem\)\,padding\(1rem\)\) {
@@ -88,11 +136,27 @@ A feature Grid with a spanning hero and a side card that can be aligned independ
 
 **description:**
 A two-column Grid editorial layout with placed items.
-**csss:**
- $Grid(startEnd,cols(repeat(2,1fr)),gap(1rem),padding(1rem))
-|$gridItem(stretchStart)
-|:nth-child(1)$gridItem(column(1,1))
-|:nth-child(2)$gridItem(row(2,span(2)),column(2))
+**userInstruction:** The editorial layout needs precise placement. Default all items to stretch and align start. Put the first child in column 1, and make the second child span two rows in column 2.
+**before:**
+```html
+…<div class="$Grid(startEnd,cols(repeat(2,1fr)),gap(1rem),padding(1rem))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(startEnd,cols(repeat(2,1fr)),gap(1rem),padding(1rem))
+  |$gridItem(stretchStart)
+  |:nth-child(1)$gridItem(column(1,1))
+  |:nth-child(2)$gridItem(row(2,span(2)),column(2))">
+  <div>…</div>
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(startEnd\,cols\(repeat\(2\,1fr\)\)\,gap\(1rem\)\,padding\(1rem\)\) {
@@ -123,11 +187,27 @@ A two-column Grid editorial layout with placed items.
 
 **description:**
 A collage Grid with a wide featured panel, a centered highlight tile, and a tall supporting column.
-**csss:**
- $Grid(cols(repeat(3,1fr)),rows(repeat(3,80px)),gap(1rem),padding(1rem))
-|.a$gridItem(column(1,span(2)),row(1))
-|.b$gridItem(center,column(3),row(2))
-|.c$gridItem(stretchStart,column(1),row(2,span(2)))
+**userInstruction:** The grid cells are flowing automatically, but we need a specific collage layout. Manually position .a to span 2 columns in row 1, .b to center in column 3 of row 2, and .c to span 2 rows starting in column 1.
+**before:**
+```html
+…<div class="$Grid(cols(repeat(3,1fr)),rows(repeat(3,80px)),gap(1rem),padding(1rem))">
+  <div class="a">…</div>
+  <div class="b">…</div>
+  <div class="c">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(cols(repeat(3,1fr)),rows(repeat(3,80px)),gap(1rem),padding(1rem))
+  |.a$gridItem(column(1,span(2)),row(1))
+  |.b$gridItem(center,column(3),row(2))
+  |.c$gridItem(stretchStart,column(1),row(2,span(2)))">
+  <div class="a">…</div>
+  <div class="b">…</div>
+  <div class="c">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(cols\(repeat\(3\,1fr\)\)\,rows\(repeat\(3\,80px\)\)\,gap\(1rem\)\,padding\(1rem\)\) {
@@ -162,9 +242,23 @@ A collage Grid with a wide featured panel, a centered highlight tile, and a tall
 
 **description:**
 A scrollable Grid gallery with a wide first item.
-**csss:**
- $Grid(cols(repeat(4,1fr)),gap(1rem))$box(scrollHidden)
-|:nth-child(1)$gridItem(column(1,span(3)))
+**userInstruction:** The 4-column gallery overflows its container horizontally. Add a scroll box to allow horizontal scrolling but hide vertical overflow, and make the first child prominently span 3 columns.
+**before:**
+```html
+…<div class="$Grid(cols(repeat(4,1fr)),gap(1rem))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $Grid(cols(repeat(4,1fr)),gap(1rem))$box(scrollHidden)
+  |:nth-child(1)$gridItem(column(1,span(3)))">
+  <div>…</div>
+  <div>…</div>
+</div>…
+```
 **css:**
 ```css
 .\$Grid\(cols\(repeat\(4\,1fr\)\)\,gap\(1rem\)\)\$box\(scrollHidden\) {

--- a/shots/genre/grid.md
+++ b/shots/genre/grid.md
@@ -80,7 +80,7 @@ A column-flow Grid board with a tall spanning item.
 
 **description:**
 A feature Grid with a spanning hero and a side card that can be aligned independently for contrast.
-**userInstruction:** Set the grid to stretch all items by default using |$. Then, make the .hero item span two columns with a 1rem margin, and align the .aside to the start and end of row 2.
+**userInstruction:** Set the grid to stretch all items by default. Then, make the hero item span two columns with a 1rem margin, and align the aside to the start and end of row 2.
 **before:**
 ```html
 …<div class="$Grid(center,cols(repeat(2,1fr)),gap(1rem),padding(1rem))">

--- a/shots/genre/iBlock.md
+++ b/shots/genre/iBlock.md
@@ -1,8 +1,22 @@
 **description:**
 An IBlock badge row with centered text, padding, and even spacing.
-**csss:**
- $IBlock(padding(0.5rem))$paragraph(center)
-|$IBlockItem(margin(1rem,0,0.5rem))
+**userInstruction:** The badges are packed too tightly and have no internal padding. Add 0.5rem padding, center the text, and separate the items with an inline-block spacing using the general child selector |$.
+**before:**
+```html
+…<div class="$IBlock">
+  <span>…</span>
+  <span>…</span>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $IBlock(padding(0.5rem))$paragraph(center)
+  |$IBlockItem(margin(1rem,0,0.5rem))">
+  <span>…</span>
+  <span>…</span>
+</div>…
+```
 **css:**
 ```css
 .\$IBlock\(padding\(0\.5rem\)\)\$paragraph\(center\) {
@@ -21,9 +35,23 @@ An IBlock badge row with centered text, padding, and even spacing.
 
 **description:**
 An IBlock stat row with hidden overflow, padding, and shared spacing.
-**csss:**
- $IBlock(padding(0.5rem))$box(hidden)
-|$IBlockItem(margin(1rem,0,0.5rem))
+**userInstruction:** Long stat numbers are pushing the bounds of the container. Hide the overflow and ensure the child items have consistent margin spacing using |$.
+**before:**
+```html
+…<div class="$IBlock(padding(0.5rem))">
+  <div class="stat">…</div>
+  <div class="stat">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $IBlock(padding(0.5rem))$box(hidden)
+  |$IBlockItem(margin(1rem,0,0.5rem))">
+  <div class="stat">…</div>
+  <div class="stat">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$IBlock\(padding\(0\.5rem\)\)\$box\(hidden\) {
@@ -42,10 +70,24 @@ An IBlock stat row with hidden overflow, padding, and shared spacing.
 
 **description:**
 An IBlock card row with padding, fixed width, and mixed alignment, where edge items can opt into top alignment.
-**csss:**
- $IBlock(padding(1rem))$paragraph(center)
-|$paragraphItem(middle)$Box(200px)
-|.edge$paragraphItem(top)
+**userInstruction:** The cards are varying in width and aligning unpredictably. Set a fixed 200px width and middle alignment for all children, but allow the .edge card to align to the top.
+**before:**
+```html
+…<div class="$IBlock(padding(1rem))$paragraph(center)">
+  <div>…</div>
+  <div class="edge">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $IBlock(padding(1rem))$paragraph(center)
+  |$paragraphItem(middle)$Box(200px)
+  |.edge$paragraphItem(top)">
+  <div>…</div>
+  <div class="edge">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$IBlock\(padding\(1rem\)\)\$paragraph\(center\) {
@@ -74,10 +116,24 @@ An IBlock card row with padding, fixed width, and mixed alignment, where edge it
 
 **description:**
 An inline media row with centered text and mixed top and middle alignment.
-**csss:**
- $IBlock(padding(0.5rem))$paragraph(center)
-|.lead$iBlockItem(margin(0,1rem,1rem,0))$paragraphItem(top)
-|.cta$paragraphItem(middle)
+**userInstruction:** The .lead and .cta elements are sitting on the same baseline. Refactor this to align the .lead to the top with some margin, and align the .cta to the middle.
+**before:**
+```html
+…<div class="$IBlock(padding(0.5rem))$paragraph(center)">
+  <div class="lead">…</div>
+  <div class="cta">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $IBlock(padding(0.5rem))$paragraph(center)
+  |.lead$iBlockItem(margin(0,1rem,1rem,0))$paragraphItem(top)
+  |.cta$paragraphItem(middle)">
+  <div class="lead">…</div>
+  <div class="cta">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$IBlock\(padding\(0\.5rem\)\)\$paragraph\(center\) {
@@ -99,11 +155,25 @@ An inline media row with centered text and mixed top and middle alignment.
 
 **description:**
 An IBlock metadata row with padding, shared spacing, plus width and alignment overrides on selected items.
-**csss:**
- $IBlock(padding(0.75rem))$paragraph(center)
-|$IBlockItem(margin(0.5rem,1rem))$paragraphItem(middle)
-|.card$box(240px)
-|.meta$box(120px)$paragraphItem(top)
+**userInstruction:** The metadata elements are squished. Give all children a 0.5rem block / 1rem inline margin, set a 240px width for .card, and a 120px width and top alignment for .meta.
+**before:**
+```html
+…<div class="$IBlock(padding(0.75rem))$paragraph(center)">
+  <div class="card">…</div>
+  <div class="meta">…</div>
+</div>…
+```
+**after:**
+```html
+…<div class="
+  $IBlock(padding(0.75rem))$paragraph(center)
+  |$IBlockItem(margin(0.5rem,1rem))$paragraphItem(middle)
+  |.card$box(240px)
+  |.meta$box(120px)$paragraphItem(top)">
+  <div class="card">…</div>
+  <div class="meta">…</div>
+</div>…
+```
 **css:**
 ```css
 .\$IBlock\(padding\(0\.75rem\)\)\$paragraph\(center\) {

--- a/shots/genre/iBlock.md
+++ b/shots/genre/iBlock.md
@@ -1,6 +1,6 @@
 **description:**
 An IBlock badge row with centered text, padding, and even spacing.
-**userInstruction:** The badges are packed too tightly and have no internal padding. Add 0.5rem padding, center the text, and separate the items with an inline-block spacing using the general child selector |$.
+**userInstruction:** The badges are packed too tightly and have no internal padding. Add 0.5rem padding, center the text, and separate the items with an inline-block spacing.
 **before:**
 ```html
 …<div class="$IBlock">
@@ -35,7 +35,7 @@ An IBlock badge row with centered text, padding, and even spacing.
 
 **description:**
 An IBlock stat row with hidden overflow, padding, and shared spacing.
-**userInstruction:** Long stat numbers are pushing the bounds of the container. Hide the overflow and ensure the child items have consistent margin spacing using |$.
+**userInstruction:** Long stat numbers are pushing the bounds of the container. Hide the overflow and ensure the child items have consistent margin spacing.
 **before:**
 ```html
 …<div class="$IBlock(padding(0.5rem))">

--- a/shots/units/box.md
+++ b/shots/units/box.md
@@ -1,22 +1,8 @@
 **description:**
 A horizontal scrolling container with snapping and custom inline sizing constraints, along with items that center-snap and have scroll margins.
-**userInstruction:** The horizontal list currently scrolls freely and allows content to stretch infinitely. Constrain its width between 100px and 800px, and implement mandatory inline scroll snapping so items lock into the center.
-**before:**
-```html
-…<div class="$Box(100%,scroll)">
-  <div>…</div>
-  <div>…</div>
-</div>…
-```
-**after:**
-```html
-…<div class="
-  $Box(100px<100%<800px,scroll,snapInlineMandatory,scrollPadding(0,1rem))
-  |$BoxItem(snapCenter,scrollMargin(0,1rem))">
-  <div>…</div>
-  <div>…</div>
-</div>…
-```
+**csss:**
+ $Box(100px<100%<800px,scroll,snapInlineMandatory,scrollPadding(0,1rem))
+|$BoxItem(snapCenter,scrollMargin(0,1rem))
 **css:**
 ```css
 .\$Box\(100px\<100\%\<800px\,scroll\,snapInlineMandatory\,scrollPadding\(0\,1rem\)\) {
@@ -42,25 +28,9 @@ A horizontal scrolling container with snapping and custom inline sizing constrai
 
 **description:**
 A fixed-size vertical scrolling block container with hidden overflow on the inline axis and mandatory block snapping. Items align to start and stop always.
-**userInstruction:** Users are scrolling past items too quickly in the vertical feed. Enforce mandatory block snapping so the scroll always stops at the start of an item.
-**before:**
-```html
-…<div class="$Box(100%,300px,hiddenScroll)">
-  …
-  <div>…</div>
-  …
-</div>…
-```
-**after:**
-```html
-…<div class="
-  $Box(100%,300px,hiddenScroll,snapBlockMandatory)
-  |$BoxItem(snapStart,snapAlways)">
-  …
-  <div>…</div>
-  …
-</div>…
-```
+**csss:**
+ $Box(100%,300px,hiddenScroll,snapBlockMandatory)
+|$BoxItem(snapStart,snapAlways)
 **css:**
 ```css
 .\$Box\(100\%\,300px\,hiddenScroll\,snapBlockMandatory\) {
@@ -84,19 +54,8 @@ A fixed-size vertical scrolling block container with hidden overflow on the inli
 
 **description:**
 A standard modal layout using a Box with auto overflow, max block constraints to ensure it scrolls if content is too long, and scroll paddings to ensure content isn't flush with the viewport.
-**userInstruction:** The modal is overflowing the screen vertically on small devices. Limit its maximum block size to 90vh and allow it to scroll automatically, adding some scroll padding so content isn't flush with the edges.
-**before:**
-```html
-…<dialog>
-  <div class="content">…</div>
-</dialog>…
-```
-**after:**
-```html
-…<dialog class="$Box(_,_<_<90vh,auto,scrollPadding(2rem))">
-  <div class="content">…</div>
-</dialog>…
-```
+**csss:**
+ $Box(_,_<_<90vh,auto,scrollPadding(2rem))
 **css:**
 ```css
 .\$Box\(_\,_\<_\<90vh\,auto\,scrollPadding\(2rem\)\) {
@@ -114,23 +73,9 @@ A standard modal layout using a Box with auto overflow, max block constraints to
 
 **description:**
 A gallery container where elements scroll automatically on the inline axis, snapping at the end of each item with scroll margin inline ends.
-**userInstruction:** The flex gallery doesn't have scroll snapping, making it hard to align images. Add inline snapping to the container, and make the children snap to their end edge with a 20px inline margin.
-**before:**
-```html
-…<div class="$Flex(row,gap(10px))$Box(100%,autoHidden)">
-  <img src="…" />
-  <img src="…" />
-</div>…
-```
-**after:**
-```html
-…<div class="
-  $Flex(row,gap(10px))$Box(100%,autoHidden,snapInline)
-  |img$BoxItem(snapEnd,scrollMargin(0,20px,0,0))">
-  <img src="…" />
-  <img src="…" />
-</div>…
-```
+**csss:**
+ $Flex(row,gap(10px))$Box(100%,autoHidden,snapInline)
+|$BoxItem(snapEnd,scrollMargin(0,20px,0,0))
 **css:**
 ```css
 .\$Flex\(row\,gap\(10px\)\)\$Box\(100\%\,autoHidden\,snapInline\) {
@@ -162,19 +107,8 @@ A gallery container where elements scroll automatically on the inline axis, snap
 
 **description:**
 A side navigation bar with fixed block bounds, visible overflow, and auto inline.
-**userInstruction:** The sidebar is taking up the full height but cuts off long content vertically. Make the block overflow visible and the inline overflow auto, while keeping the 250px inline size and 100vh block size.
-**before:**
-```html
-…<aside class="$Box(250px,100vh,hidden)">
-  <nav>…</nav>
-</aside>…
-```
-**after:**
-```html
-…<aside class="$Box(250px,100vh,visibleAuto)">
-  <nav>…</nav>
-</aside>…
-```
+**csss:**
+ $Box(250px,100vh,visibleAuto)
 **css:**
 ```css
 .\$Box\(250px\,100vh\,visibleAuto\) {
@@ -192,19 +126,8 @@ A side navigation bar with fixed block bounds, visible overflow, and auto inline
 
 **description:**
 A box utilizing both block and inline sizing with minimums and maximums, testing the complex sizing function, along with clip overflow.
-**userInstruction:** This generic box stretches too much on large screens and shrinks too much on mobile. Constrain its inline size to 80% (between 200px and 1000px) and its block size to 50% (between 100px and 500px), while keeping the overflow clipped.
-**before:**
-```html
-…<div class="$Box(80%,50%,clip)">
-  …
-</div>…
-```
-**after:**
-```html
-…<div class="$Box(200px<80%<1000px,100px<50%<500px,clip)">
-  …
-</div>…
-```
+**csss:**
+ $Box(200px<80%<1000px,100px<50%<500px,clip)
 **css:**
 ```css
 .\$Box\(200px\<80\%\<1000px\,100px\<50\%\<500px\,clip\) {
@@ -222,23 +145,9 @@ A box utilizing both block and inline sizing with minimums and maximums, testing
 
 **description:**
 A carousel layout where the items stop normally and align at the start and end using $Flex and $BoxItem.
-**userInstruction:** The flex carousel has snap enabled on the container, but the items don't know where to snap. Add a BoxItem rule to make the children align at the start and end, with normal snapping behavior.
-**before:**
-```html
-…<div class="$Flex(row)$Box(auto,snap)">
-  <div class="slide">…</div>
-  <div class="slide">…</div>
-</div>…
-```
-**after:**
-```html
-…<div class="
-  $Flex(row)$Box(auto,snap)
-  |$BoxItem(snapStartEnd,snapNormal)">
-  <div class="slide">…</div>
-  <div class="slide">…</div>
-</div>…
-```
+**csss:**
+ $Flex(row)$Box(auto,snap)
+|$BoxItem(snapStartEnd,snapNormal)
 **css:**
 ```css
 .\$Flex\(row\)\$Box\(auto\,snap\) {
@@ -269,23 +178,9 @@ A carousel layout where the items stop normally and align at the start and end u
 
 **description:**
 A vertical content feed where the Box container masks overflow outside of the block, padding the scroll area at the top and bottom.
-**userInstruction:** The vertical feed's first and last items touch the very edges of the scrollable area. Add 2rem of block scroll padding to the container, and give the children 1rem of block scroll margin so they don't sit flush against the scroll boundaries.
-**before:**
-```html
-…<div class="$Box(hiddenScroll)">
-  <article>…</article>
-  <article>…</article>
-</div>…
-```
-**after:**
-```html
-…<div class="
-  $Box(hiddenScroll,scrollPadding(2rem,0))
-  |$BoxItem(scrollMargin(1rem,0))">
-  <article>…</article>
-  <article>…</article>
-</div>…
-```
+**csss:**
+ $Box(hiddenScroll,scrollPadding(2rem,0))
+|$BoxItem(scrollMargin(1rem,0))
 **css:**
 ```css
 .\$Box\(hiddenScroll\,scrollPadding\(2rem\,0\)\) {
@@ -311,19 +206,8 @@ A vertical content feed where the Box container masks overflow outside of the bl
 
 **description:**
 A full-screen container with block and inline 100%, clipping all overflow, meant to serve as an application root.
-**userInstruction:** The root app container uses 100vh for height, which causes issues on mobile browsers with dynamic toolbars. Change both block and inline sizes to 100% and ensure all overflow is clipped so child views handle their own scrolling.
-**before:**
-```html
-…<main class="$Box(100vw,100vh)">
-  <div class="app-view">…</div>
-</main>…
-```
-**after:**
-```html
-…<main class="$Box(100%,100%,clip)">
-  <div class="app-view">…</div>
-</main>…
-```
+**csss:**
+ $Box(100%,100%,clip)
 **css:**
 ```css
 .\$Box\(100\%\,100\%\,clip\) {
@@ -341,19 +225,8 @@ A full-screen container with block and inline 100%, clipping all overflow, meant
 
 **description:**
 Testing all box sizing defaults alongside explicit scrollPadding on all four sides.
-**userInstruction:** The scroll area is flush with its boundaries. Add explicit 4-value scroll padding (10px top, 20px right, 30px bottom, 40px left) to ensure scrollable content has breathing room inside the box.
-**before:**
-```html
-…<div>
-  …
-</div>…
-```
-**after:**
-```html
-…<div class="$Box(scrollPadding(10px,20px,30px,40px))">
-  …
-</div>…
-```
+**csss:**
+ $Box(scrollPadding(10px,20px,30px,40px))
 **css:**
 ```css
 .\$Box\(scrollPadding\(10px\,20px\,30px\,40px\)\) {
@@ -372,19 +245,8 @@ Testing all box sizing defaults alongside explicit scrollPadding on all four sid
 
 **description:**
 An item designed to snap in the center of the block axis and the start of the inline axis, with specific margin constraints.
-**userInstruction:** This item is currently snapping to the start on both axes. Change it to snap to the center on the block axis and start on the inline axis, and apply explicit 4-value scroll margins.
-**before:**
-```html
-…<div class="$BoxItem(snapStart)">
-  …
-</div>…
-```
-**after:**
-```html
-…<div class="$BoxItem(snapCenterStart,scrollMargin(5px,10px,15px,20px))">
-  …
-</div>…
-```
+**csss:**
+ $BoxItem(snapCenterStart,scrollMargin(5px,10px,15px,20px))
 **css:**
 ```css
 .\$BoxItem\(snapCenterStart\,scrollMargin\(5px\,10px\,15px\,20px\)\) {
@@ -397,19 +259,8 @@ An item designed to snap in the center of the block axis and the start of the in
 
 **description:**
 A highly constrained box item enforcing a stop always behavior with snapping end center.
-**userInstruction:** Users are skipping over this crucial item when scrolling fast. Force the scroll to always stop here by adding snapAlways, and change the alignment to snap to the end on the block axis and center on the inline axis.
-**before:**
-```html
-…<div class="$BoxItem(snapEnd)">
-  …
-</div>…
-```
-**after:**
-```html
-…<div class="$BoxItem(snapEndCenter,snapAlways)">
-  …
-</div>…
-```
+**csss:**
+ $BoxItem(snapEndCenter,snapAlways)
 **css:**
 ```css
 .\$BoxItem\(snapEndCenter\,snapAlways\) {


### PR DESCRIPTION
Updated `shots/genre/iBlock.md`, `shots/genre/flex.md`, and `shots/genre/grid.md` to feature realistic before states and instructions, matching the new format applied to `block.md` and `box.md`. Also corrected the generic item selector in `box.md` to use `|$` instead of `|*$`.

---
*PR created automatically by Jules for task [3123918557092155040](https://jules.google.com/task/3123918557092155040) started by @orstavik*